### PR TITLE
fix(anaconda.yaml): webpage(regex) for cuTENSOR redist (PKG-14101)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,4 +1,7 @@
 anaconda_config_version: 1
 upstream_sources:
-  - pypi:
-      identifier: cutensor
+  # NVIDIA redist directory (libcutensor archive names), not PyPI and not CUDALibrarySamples tags.
+  # Matches aggregate-duct-tape ``NVCHECKER_OVERRIDE_GITHUB_TO_REGEX`` / distro-db ``github->webpage(regex)``.
+  - webpage:
+      url: https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/
+      regex: 'libcutensor-linux-x86_64-([\d.]+)(?:_cuda\d+)?-archive\.tar\.xz'


### PR DESCRIPTION
## Summary
`anaconda.yaml` incorrectly used `pypi: cutensor` for version discovery. The recipe builds from **NVIDIA redist** tarballs, not the PyPI project.

## Change
- `webpage` + regex on the public **linux-x64** redist index (same policy as `NVCHECKER_OVERRIDE_GITHUB_TO_REGEX["cutensor"]` in aggregate-duct-tape).

## Context
- **PKG-14101** / distro-db `github->webpage(regex)` expected `yaml_source_type=webpage`.

Made with [Cursor](https://cursor.com)