### PR TITLE
update to 2.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.6.0.4" %}
+{% set version = "2.7.0.5" %}
 
 {% set cuda_major = cuda_compiler_version.split(".")[0]|int %}
 
@@ -8,12 +8,12 @@
 {% set extension = "tar.xz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
 
-{% set sha = "28dbda315a95b3edc58af986ff1b886dcf2bd1c9651094539011bbce234cb9ae" %}  # [linux64 and (cuda_compiler_version or "").startswith("12")]
-{% set sha = "f057367cabfc459b5e66e295b724b00ed780defda3ccfb62a98c8817df46b8b5" %}  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
-{% set sha = "05e29d4dd2472b2261893979f2e35b7ef27563ba47976ecdc121d88660d86186" %}  # [win64 and (cuda_compiler_version or "").startswith("12")]
-{% set sha = "f70003a4817da3db2f1f7726328c31332ada89a496446fe30b90f414eccda487" %}  # [linux64 and (cuda_compiler_version or "").startswith("13")]
-{% set sha = "f9e85439174f64d6e84db9ea54b101a24ca751b7e94ceccbfd5181be22980310" %}  # [aarch64 and (cuda_compiler_version or "").startswith("13")]
-{% set sha = "005257fb07789669605eaa4e6e5cf46a55dbade3194db03931cdbb900711e626" %}  # [win64 and (cuda_compiler_version or "").startswith("13")]
+{% set sha = "1540c437f4e18327731145e952daad24041be5bd7152bfef6c7c93cf8d69e7ed" %}  # [linux64 and (cuda_compiler_version or "").startswith("12")]
+{% set sha = "056eb7234e6f79e7424bb14eb7333325ed6e294cc1128698c7030a6979835908" %}  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
+{% set sha = "4dad09693f978ae15927d395eb228e288fa59732597f7c42f8a44321bcf71cc7" %}  # [win64 and (cuda_compiler_version or "").startswith("12")]
+{% set sha = "8f15c8094075bda122d41e0d1e7a53d73fc9555524862d171046178a24340cd4" %}  # [linux64 and (cuda_compiler_version or "").startswith("13")]
+{% set sha = "d81acd749552214ebaef3606bdd41f7c373b8c3ff9524cc7050a728372777952" %}  # [aarch64 and (cuda_compiler_version or "").startswith("13")]
+{% set sha = "84549d31acb88cdee1c3f307e662285fafa4e5ab0cbcf2d29bf8587d9f9a301f" %}  # [win64 and (cuda_compiler_version or "").startswith("13")]
 
 package:
   name: cutensor


### PR DESCRIPTION
cutensor 2.7.0

**Destination channel:** defaults

### Links
- [PKG-15845](https://anaconda.atlassian.net/browse/PKG-15845)
- [cuTENSOR v2.7.0 release notes](https://docs.nvidia.com/cuda/cutensor/latest/release_notes.html#cutensor-v2-7-0)
- Reference: [conda-forge/cutensor-feedstock#82](https://github.com/conda-forge/cutensor-feedstock/pull/82)

### Explanation of changes:
- Update the cuTENSOR redist repack from **2.6.0.4 → 2.7.0.5** (version + sha256 only; no dependency or structural changes — matches CF PR #82).
- All 4 active sha256s (linux-64 + linux-aarch64 × cuda 12/13) **verified** against the NVIDIA redist server; win sha256s updated to match (win remains skipped per SIR-2295).
- Variants unchanged: cuda 12.9 + 13.0, zipped with libcublas 12/13.
- No downstream rebuilds — consumers (cuquantum/nvmath) pin compatible ranges within cuTENSOR 2.x.

[PKG-15845]: https://anaconda.atlassian.net/browse/PKG-15845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ